### PR TITLE
Clean up navigation classes

### DIFF
--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/navigation/home/HomeDestination.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/navigation/home/HomeDestination.kt
@@ -6,8 +6,8 @@ import app.futured.kmptemplate.feature.ui.second.SecondComponent
 import app.futured.kmptemplate.feature.ui.second.SecondScreen
 import app.futured.kmptemplate.feature.ui.third.ThirdComponent
 import app.futured.kmptemplate.feature.ui.third.ThirdScreen
-import app.futured.kmptemplate.util.arch.Component
 import app.futured.kmptemplate.util.arch.Destination
+import app.futured.kmptemplate.util.arch.NavEntry
 import com.arkivanov.decompose.ComponentContext
 import kotlinx.serialization.Serializable
 
@@ -34,7 +34,7 @@ sealed class HomeDestination : Destination<HomeEntry> {
     }
 }
 
-sealed class HomeEntry : Component {
+sealed class HomeEntry : NavEntry {
     data class First(val screen: FirstScreen) : HomeEntry()
     data class Second(val screen: SecondScreen) : HomeEntry()
     data class Third(val screen: ThirdScreen) : HomeEntry()

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/navigation/home/HomeNavigation.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/navigation/home/HomeNavigation.kt
@@ -1,36 +1,14 @@
 package app.futured.kmptemplate.feature.navigation.home
 
-import app.futured.kmptemplate.util.arch.Component
-import app.futured.kmptemplate.util.arch.StackNavigator
-import app.futured.kmptemplate.util.ext.asStateFlow
-import app.futured.kmptemplate.util.ext.componentCoroutineScope
 import com.arkivanov.decompose.Child
-import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.stack.ChildStack
-import com.arkivanov.decompose.router.stack.StackNavigation
-import com.arkivanov.decompose.router.stack.childStack
 import kotlinx.coroutines.flow.StateFlow
 
-interface HomeNavigation : Component {
+interface HomeNavigation {
     val stack: StateFlow<ChildStack<HomeDestination, HomeEntry>>
     val actions: Actions
 
     interface Actions {
         fun iosPopTo(newStack: List<Child<HomeDestination, HomeEntry>>)
     }
-}
-
-class HomeStackNavigator(
-    private val stackNavigator: StackNavigation<HomeDestination>,
-) : StackNavigator<HomeDestination>, StackNavigation<HomeDestination> by stackNavigator {
-
-    fun createStack(componentContext: ComponentContext) = componentContext.childStack(
-        source = stackNavigator,
-        serializer = HomeDestination.serializer(),
-        key = this::class.simpleName.toString(),
-        initialStack = { listOf(HomeDestination.First("some")) },
-        handleBackButton = true,
-        childFactory = { config, childContext -> config.createComponent(childContext) },
-    )
-        .asStateFlow(componentContext.componentCoroutineScope())
 }

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/navigation/home/HomeStackNavigator.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/navigation/home/HomeStackNavigator.kt
@@ -1,0 +1,22 @@
+package app.futured.kmptemplate.feature.navigation.home
+
+import app.futured.kmptemplate.util.ext.asStateFlow
+import app.futured.kmptemplate.util.ext.componentCoroutineScope
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.router.stack.StackNavigation
+import com.arkivanov.decompose.router.stack.childStack
+
+class HomeStackNavigator(
+    private val stackNavigator: StackNavigation<HomeDestination>,
+) : StackNavigation<HomeDestination> by stackNavigator {
+
+    internal fun createStack(componentContext: ComponentContext) = componentContext.childStack(
+        source = stackNavigator,
+        serializer = HomeDestination.serializer(),
+        key = this::class.simpleName.toString(),
+        initialStack = { listOf(HomeDestination.First("some")) },
+        handleBackButton = true,
+        childFactory = { config, childContext -> config.createComponent(childContext) },
+    )
+        .asStateFlow(componentContext.componentCoroutineScope())
+}

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/navigation/root/RootDestination.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/navigation/root/RootDestination.kt
@@ -4,8 +4,8 @@ import app.futured.kmptemplate.feature.navigation.home.HomeNavigation
 import app.futured.kmptemplate.feature.navigation.home.HomeNavigationComponent
 import app.futured.kmptemplate.feature.ui.login.LoginComponent
 import app.futured.kmptemplate.feature.ui.login.LoginScreen
-import app.futured.kmptemplate.util.arch.Component
 import app.futured.kmptemplate.util.arch.Destination
+import app.futured.kmptemplate.util.arch.NavEntry
 import com.arkivanov.decompose.ComponentContext
 import kotlinx.serialization.Serializable
 
@@ -24,7 +24,7 @@ sealed class RootDestination : Destination<RootEntry> {
     }
 }
 
-sealed class RootEntry : Component {
+sealed class RootEntry : NavEntry {
     data class Login(val screen: LoginScreen) : RootEntry()
     data class Home(val navigation: HomeNavigation) : RootEntry()
 }

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/navigation/root/RootSlotNavigator.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/navigation/root/RootSlotNavigator.kt
@@ -1,6 +1,5 @@
 package app.futured.kmptemplate.feature.navigation.root
 
-import app.futured.kmptemplate.util.arch.SlotNavigator
 import app.futured.kmptemplate.util.ext.asStateFlow
 import app.futured.kmptemplate.util.ext.componentCoroutineScope
 import com.arkivanov.decompose.ComponentContext
@@ -9,17 +8,15 @@ import com.arkivanov.decompose.router.slot.childSlot
 
 class RootSlotNavigator(
     private val slotNavigator: SlotNavigation<RootDestination>,
-) : SlotNavigator<RootDestination>, SlotNavigation<RootDestination> by slotNavigator {
+) : SlotNavigation<RootDestination> by slotNavigator {
 
-    fun createSlot(componentContext: ComponentContext) =
-        componentContext.childSlot(
-            source = slotNavigator,
-            serializer = RootDestination.serializer(),
-            initialConfiguration = { RootDestination.Login },
-            handleBackButton = false,
-            childFactory = { destination, childContext ->
-                destination.createComponent(childContext)
-            },
-        )
-            .asStateFlow(componentContext.componentCoroutineScope())
+    internal fun createSlot(componentContext: ComponentContext) = componentContext.childSlot(
+        source = slotNavigator,
+        serializer = RootDestination.serializer(),
+        initialConfiguration = { RootDestination.Login },
+        handleBackButton = false,
+        childFactory = { destination, childContext ->
+            destination.createComponent(childContext)
+        },
+    ).asStateFlow(componentContext.componentCoroutineScope())
 }

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/first/FirstScreen.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/first/FirstScreen.kt
@@ -1,10 +1,9 @@
 package app.futured.kmptemplate.feature.ui.first
 
-import app.futured.kmptemplate.util.arch.Component
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
-interface FirstScreen : Component {
+interface FirstScreen {
     val viewState: StateFlow<FirstViewState>
     val actions: Actions
     val events: Flow<FirstUiEvent>

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/login/LoginScreen.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/login/LoginScreen.kt
@@ -1,9 +1,8 @@
 package app.futured.kmptemplate.feature.ui.login
 
-import app.futured.kmptemplate.util.arch.Component
 import kotlinx.coroutines.flow.StateFlow
 
-interface LoginScreen : Component {
+interface LoginScreen {
     val viewState: StateFlow<LoginViewState>
     val actions: Actions
     val suspendActions: SuspendActions

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/second/SecondScreen.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/second/SecondScreen.kt
@@ -1,9 +1,8 @@
 package app.futured.kmptemplate.feature.ui.second
 
-import app.futured.kmptemplate.util.arch.Component
 import kotlinx.coroutines.flow.StateFlow
 
-interface SecondScreen : Component {
+interface SecondScreen {
     val viewState: StateFlow<SecondViewState>
     val actions: Actions
 

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/third/ThirdScreen.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/third/ThirdScreen.kt
@@ -1,9 +1,8 @@
 package app.futured.kmptemplate.feature.ui.third
 
-import app.futured.kmptemplate.util.arch.Component
 import kotlinx.coroutines.flow.StateFlow
 
-interface ThirdScreen : Component {
+interface ThirdScreen {
     val viewState: StateFlow<ThirdViewState>
     val actions: Actions
 

--- a/shared/util/src/commonMain/kotlin/app/futured/kmptemplate/util/arch/Navigation.kt
+++ b/shared/util/src/commonMain/kotlin/app/futured/kmptemplate/util/arch/Navigation.kt
@@ -1,0 +1,16 @@
+package app.futured.kmptemplate.util.arch
+
+import com.arkivanov.decompose.ComponentContext
+
+/**
+ * This interface is used to mark a class as a navigation entry.
+ * This class usually wraps instance of a screen.
+ */
+interface NavEntry
+
+/**
+ * A base interface for destinations used in Decompose navigation.
+ */
+interface Destination<out C : NavEntry> {
+    fun createComponent(componentContext: ComponentContext): C
+}

--- a/shared/util/src/commonMain/kotlin/app/futured/kmptemplate/util/arch/Navigation.kt
+++ b/shared/util/src/commonMain/kotlin/app/futured/kmptemplate/util/arch/Navigation.kt
@@ -4,7 +4,7 @@ import com.arkivanov.decompose.ComponentContext
 
 /**
  * This interface is used to mark a class as a navigation entry.
- * This class usually wraps instance of a screen.
+ * The implementation of this interface wraps instance of a screen.
  */
 interface NavEntry
 

--- a/shared/util/src/commonMain/kotlin/app/futured/kmptemplate/util/arch/ViewModelComponent.kt
+++ b/shared/util/src/commonMain/kotlin/app/futured/kmptemplate/util/arch/ViewModelComponent.kt
@@ -16,13 +16,3 @@ abstract class ViewModelComponent<VM : SharedViewModel<*, *>>(
 
     private val coroutineScope = componentCoroutineScope()
 }
-
-interface StackNavigator<D : Destination<Component>>
-
-interface SlotNavigator<D> where D : Destination<Component>
-
-interface Component
-
-interface Destination<out C : Component> {
-    fun createComponent(componentContext: ComponentContext): C
-}


### PR DESCRIPTION
- Rename `Component` interface to `NavEntry`, remove where unnecessary, extract to new file and add documentation.
- Remove `StackNavigator` and `SlotNavigator` interfaces as they serve no purpose.