### PR TITLE
Disable baseline profiles in release workflow

### DIFF
--- a/.github/workflows/android_google_play_release.yml
+++ b/.github/workflows/android_google_play_release.yml
@@ -33,8 +33,8 @@ jobs:
           java-version: '17'
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-      - name: Generate baseline profiles
-        run: ./gradlew generateReleaseBaselineProfile -P buildkonfig.flavor=${{env.KMP_FLAVOR}}
+      # TODO https://github.com/futuredapp/kmp-futured-template/issues/89 - name: Generate baseline profiles
+      #  run: ./gradlew generateReleaseBaselineProfile -P buildkonfig.flavor=${{env.KMP_FLAVOR}}
       - name: Generate app bundle
         shell: bash
         env:


### PR DESCRIPTION
Due to https://github.com/futuredapp/kmp-futured-template/issues/89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Modified the GitHub Actions workflow for Android Google Play Release by disabling the step for generating baseline profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->