### PR TITLE
Fix init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,28 +197,28 @@ navigation state in KMP.
 The following meta-description provides an overview of Decompose navigation tree:
 
 ```kotlin
-Navigation("RootNavHost") {
+Navigation("Root") {
     Slot {
-        Screen("LoginScreen")
-        Navigation("SignedInNavHost") {
+        Screen("Login")
+        Navigation("SignedIn") {
             // Bottom navigation stack
             Stack {
                 // Home tab
-                Navigation("HomeNavHost") {
+                Navigation("Home") {
                     Stack {
-                        Screen("FirstScreen")
-                        Screen("SecondScreen") {
+                        Screen("First")
+                        Screen("Second") {
                             Slot {
                                 Screen("Picker")
                             }
                         }
-                        Screen("ThirdScreen")
+                        Screen("Third")
                     }
                 }
                 // Profile tab
-                Navigation("ProfileNavHost") {
+                Navigation("Profile") {
                     Stack {
-                        Screen("ProfileScreen")
+                        Screen("Profile")
                     }
                 }
             }

--- a/init_template.main.kts
+++ b/init_template.main.kts
@@ -117,7 +117,7 @@ moveFileTree(
     toPath = Path.of("$appName.xcodeproj"),
 )
 Files.move(
-    File("iosApp/iosAppTests/iosAppTests.swift").toPath(),
+    File("iosApp/iosAppTests/AppTests.swift").toPath(),
     File("iosApp/iosAppTests/${appName}Tests.swift").toPath(),
 )
 moveFileTree(
@@ -125,16 +125,6 @@ moveFileTree(
     fromPath = Path.of("iosAppTests"),
     toPath = Path.of("${appName}Tests"),
 )
-Files.move(
-    File("iosApp/iosAppUITests/iosAppUITestsLaunchTests.swift").toPath(),
-    File("iosApp/iosAppUITests/${appName}UITestsLaunchTests.swift").toPath(),
-)
-moveFileTree(
-    parent = Path.of("iosApp"),
-    fromPath = Path.of("iosAppUITests"),
-    toPath = Path.of("${appName}UITests"),
-)
-
 // endregion
 
 // region Repo


### PR DESCRIPTION
This pull request **updates navigation naming** conventions in the documentation DSL and **fixes the init script's references** to nonexistent Swift files.

Documentation and naming consistency:

* Updated navigation tree names and screen identifiers in the `README.md` to use more concise and consistent naming conventions (e.g., `Root`, `Login`, `SignedIn`, `Home`, `Profile`, etc.) instead of the previous verbose names (e.g., `RootNavHost`, `LoginScreen`, `ProfileNavHost`).

iOS test setup simplification:

* Modified the initialization script (`init_template.main.kts`) to rename the main iOS test file from `AppTests.swift` and move it to a new location using the app name, while removing the logic that handled UI test files and directories. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified code examples in the README navigation-tree snippet with clearer, more concise identifier names for improved readability.

* **Chores**
  * Updated iOS test file organization during project initialization to better align test file naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->