### PR TITLE
Bump Arkitekt to 6.1.0 and adopt ResultKey API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,6 @@ buildkonfig.flavor=dev
 
 #Moko
 moko.resources.disableStaticFrameworkWarning=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ benchmarkMacroJunit4 = "1.4.1"
 profileinstaller = "1.4.1"
 google-servicesPlugin = "4.4.2"
 google-firebaseAppDistributionPlugin = "5.2.0"
-arkitekt = "6.0.0"
+arkitekt = "6.1.0"
 
 # Android Namespaces
 project-android-namespace = "app.futured.kmptemplate.android"

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/navigation/result/NavigationResultKeys.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/navigation/result/NavigationResultKeys.kt
@@ -1,0 +1,7 @@
+package app.futured.kmptemplate.feature.navigation.result
+
+import app.futured.arkitekt.decompose.navigation.ResultKey
+
+object NavigationResultKeys {
+    val Picker = ResultKey<String>("picker_result")
+}

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/base/AppComponentContext.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/base/AppComponentContext.kt
@@ -1,6 +1,7 @@
 package app.futured.kmptemplate.feature.ui.base
 
 import app.futured.arkitekt.decompose.ArkitektComponentContext
+import app.futured.arkitekt.decompose.navigation.NavigationResultRegistry
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.ComponentContextFactory
 import com.arkivanov.essenty.backhandler.BackHandlerOwner
@@ -19,16 +20,26 @@ interface AppComponentContext : ArkitektComponentContext<AppComponentContext>
  *
  * @param componentContext [ComponentContext] to wrap.
  */
-class DefaultAppComponentContext(componentContext: ComponentContext) :
+class DefaultAppComponentContext(
+    componentContext: ComponentContext,
+    override val navigationResultRegistry: NavigationResultRegistry,
+) :
     AppComponentContext,
     LifecycleOwner by componentContext,
     StateKeeperOwner by componentContext,
     InstanceKeeperOwner by componentContext,
     BackHandlerOwner by componentContext {
 
+    constructor(
+        componentContext: ComponentContext,
+    ) : this(
+        componentContext = componentContext,
+        navigationResultRegistry = NavigationResultRegistry(componentContext.stateKeeper),
+    )
+
     override val componentContextFactory: ComponentContextFactory<AppComponentContext> =
         ComponentContextFactory { lifecycle, stateKeeper, instanceKeeper, backHandler ->
             val ctx = componentContext.componentContextFactory(lifecycle, stateKeeper, instanceKeeper, backHandler)
-            DefaultAppComponentContext(ctx)
+            DefaultAppComponentContext(ctx, navigationResultRegistry)
         }
 }

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/picker/FruitPickerComponent.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/picker/FruitPickerComponent.kt
@@ -1,6 +1,7 @@
 package app.futured.kmptemplate.feature.ui.picker
 
 import app.futured.arkitekt.annotation.GenerateFactory
+import app.futured.arkitekt.decompose.navigation.resultFlow
 import app.futured.kmptemplate.feature.ui.base.AppComponentContext
 import app.futured.kmptemplate.feature.ui.base.ScreenComponent
 import app.futured.kmptemplate.resources.MR
@@ -48,7 +49,7 @@ internal class FruitPickerComponent(
     }
 
     override fun onPick(item: String) = launchWithHandler {
-        args.results.sendResult(item)
+        resultFlow(args.resultKey).sendResult(item)
         dismiss()
     }
 

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/picker/PickerArgs.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/picker/PickerArgs.kt
@@ -1,10 +1,10 @@
 package app.futured.kmptemplate.feature.ui.picker
 
-import app.futured.arkitekt.decompose.navigation.ResultFlow
+import app.futured.arkitekt.decompose.navigation.ResultKey
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class PickerArgs(val results: ResultFlow<String>)
+data class PickerArgs(val resultKey: ResultKey<String>)
 
 enum class PickerType {
     Fruit,

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/picker/VegetablePickerComponent.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/picker/VegetablePickerComponent.kt
@@ -1,6 +1,7 @@
 package app.futured.kmptemplate.feature.ui.picker
 
 import app.futured.arkitekt.annotation.GenerateFactory
+import app.futured.arkitekt.decompose.navigation.resultFlow
 import app.futured.kmptemplate.feature.ui.base.AppComponentContext
 import app.futured.kmptemplate.feature.ui.base.ScreenComponent
 import app.futured.kmptemplate.resources.MR
@@ -49,7 +50,7 @@ internal class VegetablePickerComponent(
     }
 
     override fun onPick(item: String) = launchWithHandler {
-        args.results.sendResult(item)
+        resultFlow(args.resultKey).sendResult(item)
         dismiss()
     }
 

--- a/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/secondScreen/SecondComponent.kt
+++ b/shared/feature/src/commonMain/kotlin/app/futured/kmptemplate/feature/ui/secondScreen/SecondComponent.kt
@@ -1,14 +1,16 @@
 package app.futured.kmptemplate.feature.ui.secondScreen
 
 import app.futured.arkitekt.annotation.GenerateFactory
-import app.futured.arkitekt.decompose.navigation.ResultFlow
+import app.futured.arkitekt.decompose.navigation.resultFlow
+import app.futured.kmptemplate.feature.navigation.result.NavigationResultKeys
 import app.futured.kmptemplate.feature.ui.base.AppComponentContext
 import app.futured.kmptemplate.feature.ui.base.ScreenComponent
 import app.futured.kmptemplate.feature.ui.picker.PickerArgs
 import app.futured.kmptemplate.feature.ui.picker.PickerType
 import com.arkivanov.essenty.lifecycle.doOnCreate
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import org.koin.core.annotation.Factory
 import org.koin.core.annotation.InjectedParam
 
@@ -27,23 +29,23 @@ internal class SecondComponent(
 
     override val viewState: StateFlow<SecondViewState> = componentState
     override val actions: SecondScreen.Actions = this
-    private val pickerResults = ResultFlow<String>()
+    private val pickerResults = resultFlow(NavigationResultKeys.Picker)
 
     override fun onBack() = pop()
 
-    override fun onPickVeggie() = openPicker(PickerType.Vegetable, PickerArgs(results = pickerResults))
+    override fun onPickVeggie() = openPicker(PickerType.Vegetable, PickerArgs(NavigationResultKeys.Picker))
 
-    override fun onPickFruit() = openPicker(PickerType.Fruit, PickerArgs(results = pickerResults))
+    override fun onPickFruit() = openPicker(PickerType.Fruit, PickerArgs(NavigationResultKeys.Picker))
 
     init {
         lifecycle.doOnCreate {
-            collectResults()
+            collectPickerResults()
         }
     }
 
-    private fun collectResults() = launchWithHandler {
-        pickerResults.collectLatest { result ->
-            navigateToThird(result)
-        }
+    private fun collectPickerResults() {
+        pickerResults
+            .onEach { selection -> navigateToThird(selection) }
+            .launchIn(lifecycleScope)
     }
 }


### PR DESCRIPTION
## Summary

Bumps Arkitekt to 6.1.0 and migrates navigation results from serialized `ResultFlow` instances to lightweight `ResultKey` identifiers resolved through a shared `NavigationResultRegistry`.

## Changes

- `DefaultAppComponentContext` now owns a `NavigationResultRegistry` (backed by `stateKeeper`) and propagates it to child contexts via `componentContextFactory`. A secondary constructor keeps the existing single-arg call sites working.
- `PickerArgs` carries a `ResultKey<String>` instead of a `ResultFlow<String>`, so navigation args stay small and cheaply serializable.
- New `NavigationResultKeys` object holds the shared `Picker` key used by both the producer and consumer sides.
- `SecondComponent` collects results via `resultFlow(NavigationResultKeys.Picker)` with `onEach`/`launchIn(lifecycleScope)` instead of `collectLatest` inside a handler scope.
- Enables `org.gradle.tooling.parallel` for faster Gradle 9.4+ sync.

### Diagram

<details>
<summary>View diagram</summary>

```mermaid
flowchart LR
    subgraph before["Before — ResultFlow in args"]
        A[SecondComponent] -->|"PickerArgs(ResultFlow)"| B[PickerComponent]
        B -->|"args.results.sendResult()"| A
    end

    subgraph after["After — ResultKey + registry"]
        K["NavigationResultKeys.Picker"]
        C[SecondComponent] -->|"PickerArgs(ResultKey)"| D[PickerComponent]
        D -->|"resultFlow(key).sendResult()"| R[("NavigationResultRegistry")]
        R -->|"resultFlow(key) emits"| C
        X[DefaultAppComponentContext] -. owns .-> R
        K -.-> C
        K -.-> D
    end
```

</details>

## Notes

- Requires Arkitekt 6.1.0 — `NavigationResultRegistry`, `ResultKey`, and the `resultFlow()` extension are new in that release.
- Any custom `AppComponentContext` implementation must now provide a `navigationResultRegistry`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fruit and vegetable picker result handling through shared navigation result keys.
  * Picker selections now return results consistently to the initiating screen.
  * Added support for preserving navigation result state across component contexts.

* **Updates**
  * Updated the Arkitekt dependency to version 6.1.0.
  * Added Gradle parallel synchronization settings, requiring Gradle 9.4 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->